### PR TITLE
📶 Add RoomInfo.status to show the 3 states of the game.

### DIFF
--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -4,4 +4,4 @@ from .story import Story, StoryCreate, StoryInDB
 from .guess import Guess, GuessCreate, GuessInDB
 from .card import Card, CardCreate, CardInDB
 from .userinfo import UserInfo
-from .roominfo import RoomInfo
+from .roominfo import RoomInfo, RoomStatus

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -151,7 +151,7 @@ def test_websocket_connect():
     with client.websocket_connect(socket_url(room, user)) as websocket:
         data = websocket.receive_json()
         assert data == {
-            "status": 0,
+            "status": "WRITING",
             "waitingOn": [user.get("id")],
             "currentUsers": [
                 {
@@ -172,7 +172,7 @@ def test_websocket_with_multiple_connections():
     with client.websocket_connect(socket_url(room, user_1)) as websocket_1:
         data_1 = websocket_1.receive_json()
         assert data_1 == {
-            "status": 0,
+            "status": "WRITING",
             "waitingOn": [user_1.get("id")],
             "currentUsers": [
                 {
@@ -188,7 +188,7 @@ def test_websocket_with_multiple_connections():
             data_2 = websocket_2.receive_json()
             assert data_1 == data_2
             assert data_2 == {
-                "status": 0,
+                "status": "WRITING",
                 "waitingOn": [user_1.get("id"), user_2.get("id")],
                 "currentUsers": [
                     {
@@ -210,7 +210,7 @@ def test_websocket_with_multiple_connections():
                 assert data_1 == data_2
                 assert data_2 == data_3
                 assert data_3 == {
-                    "status": 0,
+                    "status": "WRITING",
                     "waitingOn": [user_1.get("id"), user_2.get("id")],
                     "currentUsers": [
                         {
@@ -230,7 +230,7 @@ def test_websocket_with_multiple_connections():
             data_2 = websocket_2.receive_json()
             assert data_1 == data_2
             assert data_2 == {
-                "status": 0,
+                "status": "WRITING",
                 "waitingOn": [user_1.get("id"), user_2.get("id")],
                 "currentUsers": [
                     {
@@ -249,7 +249,7 @@ def test_websocket_with_multiple_connections():
         # client_1 gets update
         data_1 = websocket_1.receive_json()
         assert data_1 == {
-            "status": 0,
+            "status": "WRITING",
             "waitingOn": [user_1.get("id")],
             "currentUsers": [
                 {

--- a/tests/test_room_info.py
+++ b/tests/test_room_info.py
@@ -1,4 +1,4 @@
-from backend.schemas import User, Room, RoomInfo, RoomType
+from backend.schemas import User, Room, RoomInfo, RoomType, RoomStatus
 from datetime import datetime
 
 
@@ -42,3 +42,22 @@ def test_empty():
     assert roominfo.empty() == False
     roominfo.remove_user(user, 2)
     assert roominfo.empty() == True
+
+
+def test_advance_room_state():
+    room = mock_room()
+    user = mock_user()
+    roominfo = RoomInfo(
+        room=room,
+        users={},
+    )
+    for x in range(6):
+        assert roominfo.status == RoomStatus.WRITING
+        roominfo.advance_status()
+        assert roominfo.status == RoomStatus.GUESSING
+        roominfo.advance_status()
+    roominfo.end_game()
+    assert roominfo.status == RoomStatus.END_GAME
+    roominfo.advance_status()
+    assert roominfo.status == RoomStatus.END_GAME
+


### PR DESCRIPTION
When the status is `RoomStatus.WRITING`, the UI could display a button for all players to "choose a new writer" (or "skip turn" which is behaviorally the same thing), keeping it in `RoomStatus.WRITING`.

When the `status` is `RoomStatus.GUESSING` then users pick the cards. They can take as long as they like. Also each player can "end voting" button displayed to change the status back to `RoomStatus.WRITING`

In both cases, there's always an "end game" button at the bottom as well.

People can play as long as they want, end the game when they want, and advance the game when they want.

What do you think?